### PR TITLE
Change relaxed policy behavior

### DIFF
--- a/CitadelService/Services/FilterServiceProvider.cs
+++ b/CitadelService/Services/FilterServiceProvider.cs
@@ -2022,7 +2022,7 @@ namespace CitadelService.Services
                         short matchedCategory = -1;
                         string trigger = null;
                         var cfg = Config;
-                        if (m_textTriggers.ContainsTrigger(dataToAnalyzeStr, out matchedCategory, out trigger, m_categoryIndex.GetIsCategoryEnabled, isHtml, cfg != null ? cfg.MaxTextTriggerScanningSize : -1))
+                        if (m_textTriggers.ContainsTrigger(dataToAnalyzeStr, out matchedCategory, out trigger, m_categoryIndex.GetIsCategoryEnabled, cfg != null && cfg.MaxTextTriggerScanningSize > 1, cfg != null ? cfg.MaxTextTriggerScanningSize : -1))
                         {
                             m_logger.Info("Triggers successfully run. matchedCategory = {0}, trigger = '{1}'", matchedCategory, trigger);
 

--- a/CitadelService/Services/FilterServiceProvider.cs
+++ b/CitadelService/Services/FilterServiceProvider.cs
@@ -1624,7 +1624,6 @@ namespace CitadelService.Services
 
         private void OnHttpMessageBegin(Uri requestUrl, string headers, byte[] body, MessageType msgType, MessageDirection msgDirection, out ProxyNextAction nextAction, out string customBlockResponseContentType, out byte[] customBlockResponse)
         {
-
             nextAction = ProxyNextAction.AllowAndIgnoreContent;
             customBlockResponseContentType = null;
             customBlockResponse = null;
@@ -1783,8 +1782,6 @@ namespace CitadelService.Services
         
         private void OnHttpMessageEnd(Uri requestUrl, string headers, byte[] body, MessageType msgType, MessageDirection msgDirection, out bool shouldBlock, out string customBlockResponseContentType, out byte[] customBlockResponse)
         {
-            m_logger.Info("OnHttpMessageEnd Uri: {0}", requestUrl.ToString());
-
             shouldBlock = false;
             customBlockResponseContentType = null;
             customBlockResponse = null;
@@ -1806,21 +1803,18 @@ namespace CitadelService.Services
 
                 if((contentType = parsedHeaders["Content-Type"]) != null)
                 {
-                    m_logger.Info("Running content classifier on Content-Type: {0}", parsedHeaders["Content-Type"]);
-
                     contentType = contentType.ToLower();
 
                     BlockType blockType;
                     var contentClassResult = OnClassifyContent(body, contentType, out blockType);
 
-                    m_logger.Info("Content classified as {0}", contentClassResult);
-                    if(contentClassResult > 0)
+                    if (contentClassResult > 0)
                     {
                         shouldBlock = true;
 
                         UriInfo uriInfo = WebServiceUtil.Default.LookupUri(requestUrl, true);
 
-                        if(contentType.IndexOf("html") != -1 || contentType.IndexOf("json") != -1)
+                        if(contentType.IndexOf("html") != -1)
                         {
                             customBlockResponseContentType = "text/html";
                             customBlockResponse = getBlockPageWithResolvedTemplates(requestUrl, 0, uriInfo, blockType);
@@ -2017,8 +2011,6 @@ namespace CitadelService.Services
                             // dataToAnalyzeStr = ext.Extract(dataToAnalyzeStr.ToCharArray(), true);
                         }
 
-                        m_logger.Info("Analyzing: {0}", dataToAnalyzeStr);
-
                         short matchedCategory = -1;
                         string trigger = null;
                         var cfg = Config;
@@ -2034,10 +2026,6 @@ namespace CitadelService.Services
                                 blockedBecause = BlockType.TextTrigger;
                                 return mappedCategory.CategoryId;
                             }
-                        }
-                        else
-                        {
-                            m_logger.Info("Triggers not successfully run.");
                         }
                     }
                 }
@@ -2710,12 +2698,8 @@ namespace CitadelService.Services
                 {
                     if (entry is MappedBypassListCategoryModel)
                     {
-                        m_logger.Info("Setting entry {0} to false", entry.CategoryName);
                         m_categoryIndex.SetIsCategoryEnabled(((MappedBypassListCategoryModel)entry).CategoryId, false);
                         //m_categoryIndex.SetIsCategoryEnabled(((MappedBypassListCategoryModel)entry).CategoryIdAsWhitelist, true);
-                    } else
-                    {
-                        m_logger.Info("Entry is not bypassable {0}", entry.CategoryName);
                     }
                 }
 
@@ -2741,7 +2725,6 @@ namespace CitadelService.Services
                     {
                         if (entry is MappedBypassListCategoryModel)
                         {
-                            m_logger.Info("Setting entry {0} to false", entry.CategoryName);
                             m_categoryIndex.SetIsCategoryEnabled(((MappedBypassListCategoryModel)entry).CategoryId, false);
                         }
                     }

--- a/CitadelService/Services/FilterServiceProvider.cs
+++ b/CitadelService/Services/FilterServiceProvider.cs
@@ -2531,26 +2531,6 @@ namespace CitadelService.Services
                                                 }
 
                                                 GC.Collect();
-
-                                                // Load second as whitelist, but start off with the
-                                                // category disabled.
-                                                /*using(TextReader tr = new StreamReader(listEntry.Open()))
-                                                {
-                                                    var bypassAsWhitelistRules = new List<string>();
-                                                    string line = null;
-                                                    while((line = tr.ReadLine()) != null)
-                                                    {
-                                                        bypassAsWhitelistRules.Add("@@" + line.Trim() + "\n");
-                                                    }
-
-                                                    var loadedFailedRes = m_filterCollection.ParseStoreRules(bypassAsWhitelistRules.ToArray(), bypassCategoryModel.CategoryIdAsWhitelist).Result;
-                                                    totalFilterRulesLoaded += (uint)loadedFailedRes.Item1;
-                                                    totalFilterRulesFailed += (uint)loadedFailedRes.Item2;
-
-                                                    //m_categoryIndex.SetIsCategoryEnabled(bypassCategoryModel.CategoryIdAsWhitelist, false);
-                                                }*/
-
-                                                GC.Collect();
                                             }
                                         }
                                         break;


### PR DESCRIPTION
First change of any value is line 2017: This contains Jesse's change to enable text trigger scans for multi-word triggers on all content types.

Line 2532: Removed whitelist initialization for bypass categories, since we are no longer whitelisting bypassable categories on relaxed policy.

Lines 2681 and 2708: Change SetIsCategoryEnabled from whitelist categories to regular categories, and turn those blacklist categories off. This is the fix for #127.